### PR TITLE
Fix symlink bug in build script

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -51,7 +51,7 @@ pandoc --verbose \
 if [ "${BUILD_PDF}" != "false" ] && [ "${MANUBOT_USE_DOCKER}" != "true" ]; then
   echo >&2 "Exporting PDF manuscript using WeasyPrint"
   if [ -L images ]; then rm images; fi  # if images is a symlink, remove it
-  ln -s content/images
+  ln -s content/images images
   pandoc \
     --data-dir="$PANDOC_DATA_DIR" \
     --defaults=common.yaml \


### PR DESCRIPTION
## Summary
- fix wrong ln syntax in `build.sh`

## Testing
- `shellcheck build/build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68486aee72a483229a8d7f302149c779