### PR TITLE
Fix typo in autobuild comment

### DIFF
--- a/build/autobuild.sh
+++ b/build/autobuild.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-## autobuild.sh: automatically rebuild mansucript outputs and the webpage when content changes
+## autobuild.sh: automatically rebuild manuscript outputs and the webpage when content changes
 ## Depends on watchdog https://github.com/gorakhargosh/watchdog
 
 watchmedo shell-command \


### PR DESCRIPTION
## Summary
- correct typo in build/autobuild.sh comment

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68486c7b6aec83229ac20b1e76b93e5a