### PR TITLE
Add DOCX conversion helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ The directories are as follows:
 + [`build`](build) contains commands and tools for building the manuscript.
 + [`ci`](ci) contains files necessary for deployment via continuous integration.
 
+### DOCX Conversion
+
+`docx_to_manubot.py` automates converting a DOCX dissertation into
+numbered Markdown files that follow the Manubot layout.
+Run the script with the input file and the output directory, for example:
+
+```sh
+./docx_to_manubot.py Dissertation.docx content
+```
+
+The script generates `00_mapping.md` with an overview of the produced files.
+
 ### Local execution
 
 The easiest way to run Manubot is to use [continuous integration](#continuous-integration) to rebuild the manuscript when the content changes.

--- a/docx_to_manubot.py
+++ b/docx_to_manubot.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Convert a DOCX dissertation into Manubot-compatible markdown files.
+
+Usage:
+    python docx_to_manubot.py Dissertation.docx content/
+"""
+
+import re
+import sys
+import subprocess
+from pathlib import Path
+
+
+def convert_docx_to_markdown(docx_path: str) -> str:
+    temp_md = Path("temp_conversion.md")
+    subprocess.run([
+        "pandoc",
+        docx_path,
+        "-t",
+        "markdown",
+        "--wrap=preserve",
+        "-o",
+        str(temp_md),
+    ], check=True)
+    text = temp_md.read_text(encoding="utf-8")
+    temp_md.unlink()
+    return text
+
+
+def slugify(text: str) -> str:
+    slug = text.lower()
+    slug = re.sub(r"[^a-z0-9]+", "-", slug)
+    return slug.strip("-")
+
+
+def split_markdown(markdown: str):
+    lines = markdown.splitlines()
+    sections = []
+    current = []
+    heading = "front-matter"
+    for line in lines:
+        if line.startswith("# "):
+            if current:
+                sections.append((heading, current))
+                current = []
+            heading = line[2:].strip()
+        current.append(line)
+    if current:
+        sections.append((heading, current))
+    return sections
+
+
+def create_toc(section_lines):
+    toc = []
+    for line in section_lines:
+        if line.startswith("##"):
+            level = len(line.split(" ")[0])
+            heading = line[level + 1:].strip()
+            slug = slugify(heading)
+            indent = "  " * (level - 2)
+            toc.append(f"{indent}- [**{heading}**](#{slug})")
+    if toc:
+        return ["## Inhaltsverzeichnis", *toc, ""]
+    return []
+
+
+def write_sections(sections, out_dir: str):
+    Path(out_dir).mkdir(exist_ok=True, parents=True)
+    mapping = []
+    for i, (title, lines) in enumerate(sections):
+        prefix = f"{i:02d}"
+        filename = f"{prefix}_{slugify(title)}.md"
+        toc = create_toc(lines)
+        content = lines[:1] + toc + lines[1:]
+        Path(out_dir, filename).write_text("\n".join(content), encoding="utf-8")
+        mapping.append((prefix, filename, title))
+    return mapping
+
+
+def write_mapping(mapping, out_dir: str):
+    lines = [
+        "# Mapping Tabelle",
+        "",
+        "| Präfix | Dateiname | Kapitelüberschrift |",
+        "|-------:|-----------|-------------------|",
+    ]
+    for prefix, fname, title in mapping:
+        lines.append(f"| {prefix} | {fname} | {title} |")
+    Path(out_dir, "00_mapping.md").write_text("\n".join(lines), encoding="utf-8")
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("Usage: python docx_to_manubot.py INPUT.docx OUTPUT_DIR")
+        sys.exit(1)
+    docx_path, out_dir = sys.argv[1:3]
+    markdown = convert_docx_to_markdown(docx_path)
+    sections = split_markdown(markdown)
+    mapping = write_sections(sections, out_dir)
+    write_mapping(mapping, out_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `docx_to_manubot.py` for converting a DOCX dissertation into a set of
  numbered Markdown files and a mapping table
- document the new script in the README

## Testing
- `python -m py_compile docx_to_manubot.py`

------
https://chatgpt.com/codex/tasks/task_e_68570b1495608322b4ca0e1c4709ddf3