### PR TITLE
Add SQLAlchemy database configuration

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,28 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+# SQLite-Engine mit Datei 'database.db'
+# check_same_thread=False erlaubt Zugriff aus verschiedenen Threads
+engine = create_engine(
+    "sqlite:///./database.db",
+    connect_args={"check_same_thread": False},
+)
+
+# Declarative Base für ORM-Modelle
+Base = declarative_base()
+
+# SessionMaker für DB-Sessions
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def get_db():
+    """Abhängigkeitsfunktion für FastAPI-Routen.
+
+    Erstellt eine Datenbank-Sitzung und gibt sie weiter. Nach Nutzung wird die
+    Sitzung ordnungsgemäß geschlossen.
+    """
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary
- initialize SQLAlchemy engine and session maker
- expose `get_db` for FastAPI dependency injection

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ae427a2dc8322b02bb1a1f4dfcb8a